### PR TITLE
Bump dnscontrol from 4.13.0 to 4.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 
 LABEL repository="https://github.com/is-cool-me/dnscontrol-action"
 LABEL maintainer="light <admin@lighthosting.eu.org>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ LABEL "com.github.actions.description"="Deploy your DNS configuration to multipl
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="yellow"
 
-ENV DNSCONTROL_VERSION="4.13.0"
-ENV DNSCONTROL_CHECKSUM="103fe932785bbfef47bc798e815a2ee88057be9b0f9aff696373a4ab3accfe10"
+ENV DNSCONTROL_VERSION="4.20.0"
+ENV DNSCONTROL_CHECKSUM="d2208719173f35d9ba3a7f6ebb94ea103a43a7e808e16a7857b27df94fa5aa94"
 ENV USER=dnscontrol-user
 
 RUN apk -U --no-cache upgrade && \


### PR DESCRIPTION
- Bump DNSControl version from 4.13.0 to 4.20.0
- Bump Alpine base image version from 3.20.3 to 3.21.3